### PR TITLE
Remove unused nullable flag from tree-walker context

### DIFF
--- a/src/queryGenerator/treeWalker/compile.ts
+++ b/src/queryGenerator/treeWalker/compile.ts
@@ -88,7 +88,6 @@ function buildRootContext(
     source: `${resourceAlias}.json`,
     partitionKeys: [idKey],
     ancestorApplies: "",
-    nullable: false,
     cteCounter: { value: 0 },
     transpilerCtx,
   };

--- a/src/queryGenerator/treeWalker/operators/forEach.ts
+++ b/src/queryGenerator/treeWalker/operators/forEach.ts
@@ -44,8 +44,8 @@ interface ForEachDeps {
  * @param node - The ForEach or ForEachOrNull select node.  `node.forEach` or
  *   `node.forEachOrNull` supplies the FHIRPath expression to iterate.
  * @param ctx - The current walker context; the inner context is derived from
- *   it by updating `source`, `partitionKeys`, `ancestorApplies`, `nullable`,
- *   and `transpilerCtx`.
+ *   it by updating `source`, `partitionKeys`, `ancestorApplies`, and
+ *   `transpilerCtx`.
  * @param walk - The recursive walk function used to visit the inner sub-tree.
  * @param deps - Dependencies containing the `PathParser` used to parse and
  *   decompose the FHIRPath expression.
@@ -72,7 +72,7 @@ export function walkForEach(
     deps.pathParser,
   );
 
-  const innerCtx = buildInnerCtx(ctx, alias, rawPath, applyClause, isOrNull);
+  const innerCtx = buildInnerCtx(ctx, alias, rawPath, applyClause);
   const innerNode: ViewDefinitionSelect = {
     column: node.column,
     select: node.select,
@@ -91,7 +91,6 @@ function buildInnerCtx(
   alias: string,
   rawPath: string,
   applyClause: string,
-  isOrNull: boolean,
 ): Context {
   const innerTranspilerCtx: TranspilerContext = {
     ...ctx.transpilerCtx,
@@ -115,7 +114,6 @@ function buildInnerCtx(
     source: `${alias}.value`,
     partitionKeys: [...ctx.partitionKeys, innerKey],
     ancestorApplies: ctx.ancestorApplies + applyClause,
-    nullable: ctx.nullable || isOrNull,
     transpilerCtx: innerTranspilerCtx,
   };
 }

--- a/src/queryGenerator/treeWalker/types.ts
+++ b/src/queryGenerator/treeWalker/types.ts
@@ -53,8 +53,6 @@ export interface Context {
    * with "\n".
    */
   ancestorApplies: string;
-  /** True if any forEachOrNull ancestor is in scope. */
-  nullable: boolean;
   /** Shared mutable counter for unique CTE/alias names across the whole compile. */
   cteCounter: { value: number };
   /** Pass-through context for the FHIRPath transpiler. */


### PR DESCRIPTION
Removes the `Context.nullable` flag from the tree-walker. It was written but never read, so it drove no behaviour - `repeat` hardcodes `INNER JOIN` and `forEach` picks its apply type from the node's own `isOrNull`. It read like a switch that should preserve `forEachOrNull` null rows, which is what prompted the PR #9 review suggestion to consume it; investigating that (#10) showed the current row-dropping behaviour is already conformant, so consuming the flag would have been a regression. Also drops the now-redundant `isOrNull` parameter and stale comments.

No generated SQL changes. The full conformance suite passes unchanged (144/144) and build, lint, and format:check are clean.

Refs #10
